### PR TITLE
Improve hover effect for theme color buttons

### DIFF
--- a/options.html
+++ b/options.html
@@ -11,11 +11,23 @@
           outline: none;
           margin: 10px;
           cursor: pointer;
+          transition: all 0.05s ease-out 0s;
         }
         .color-selector {
           width: 75px;
           display: inline-block;
           text-align: center;
+          cursor: pointer;
+          transition: all 0.05s ease-out 0s;
+        }
+        .color-selector:hover {
+          font-weight: bold;
+        }
+        .color-selector:hover button {
+          height: 37px;
+          width: 37px;
+          margin-top: 6px;
+          margin-bottom: 6px;
         }
       </style>
     </head>

--- a/options.js
+++ b/options.js
@@ -39,7 +39,7 @@ function constructColorOptions(colorThemes) {
       buttonContainer.classList.add('color-selector')
       let button = document.createElement('button');
       button.style.backgroundColor = color_value;
-      button.addEventListener('click', function() {
+      buttonContainer.addEventListener('click', function() {
       chrome.storage.sync.set({theme_color: color_value}, function() {
         console.log('Theme color set to ' + color_name + ' ' + color_value);
         });


### PR DESCRIPTION
This pull request adds a transition effect that makes the button enlarge and the text become bold when you hover over a color option. I've also moved the event listener from the button to the buttonContainer so you can click the color text and still cause the change.